### PR TITLE
Allow individual package creation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,9 +44,9 @@ lint:
 		golint -min_confidence=1 $$pkg ; \
 		done
 
-package: setup strip rpm64 deb64
+package: setup rpm64 deb64
 
-setup:
+setup: build strip
 	@mkdir -p package/root/usr/bin/
 	@mkdir -p package/root/etc/$(NAME)/
 	@mkdir -p package/root/usr/lib/systemd/system/
@@ -66,7 +66,7 @@ certs:
 
 certs-remote:
 	mkdir -p tmp
-	openssl req -x509 -sha256 -nodes -days 365 -subj "/C=us/ST=ks/L=kolide/O=kolide/CN=${cn}" -newkey rsa:2048 -keyout tmp/$(NAME).key -out tmp/$(NAME).crt
+	openssl req -x509 -sha256 -nodes -days 365 -subj "/C=us/ST=ks/L=kolide/O=kolide/CN=$$cn" -newkey rsa:2048 -keyout tmp/$(NAME).key -out tmp/$(NAME).crt
 	cp -R ./tmp/* /tmp/
 
 # docker dev
@@ -79,8 +79,8 @@ down:
 strip:
 	strip bin/$(NAME)
 
-rpm64:
-	fpm -s dir -t rpm -n $(NAME) -v $(BUILDVERSION) -p package/output/$(NAME)-$(BUILDVERSION)-amd64.rpm \
+rpm64: setup
+	fpm -s dir -t rpm -n $(NAME) -v $(BUILDVERSION) -p package/output/ \
 		--rpm-compression xz --rpm-os linux \
 		--force \
 		--before-install scripts/package/pre-inst.sh \
@@ -95,8 +95,8 @@ rpm64:
 		--exclude */**.gitkeep \
 		package/root/=/
 
-deb64:
-	fpm -s dir -t deb -n $(NAME) -v $(BUILDVERSION) -p package/output/$(NAME)-$(BUILDVERSION)-amd64.deb \
+deb64: setup
+	fpm -s dir -t deb -n $(NAME) -v $(BUILDVERSION) -p package/output/ \
 		--force \
 		--deb-compression xz \
 		--before-install scripts/package/pre-inst.sh \


### PR DESCRIPTION
Streamlines the creation of packages giving the ability to just type `make rpm64`.

Currently the binary needs to exist before one can create an RPM:
```shell
23:14:36 c1-linux (master) ~/Documents/Go/src/github.com/kolide/kolide $ make rpm64 
strip bin/kolide
strip: 'bin/kolide': No such file
make: *** [Makefile:80: strip] Error 1
23:14:42 c1-linux (master) ~/Documents/Go/src/github.com/kolide/kolide $ make build 
kolide
go version go1.7.3 linux/amd64
Go Path: /home/tlambiris/Documents/Go

Running go generate...
Building kolide...
23:16:26 c1-linux (master) ~/Documents/Go/src/github.com/kolide/kolide $ ls bin/kolide 
bin/kolide
23:16:27 c1-linux (master) ~/Documents/Go/src/github.com/kolide/kolide $ make rpm64 
strip bin/kolide
fpm -s dir -t rpm -n kolide -v 0.2.3+58.ebf59ed -p package/output/ \
	--rpm-compression xz --rpm-os linux \
	--force \
	--before-install scripts/package/pre-inst.sh \
	--after-install scripts/package/post-inst.sh \
	--before-remove scripts/package/pre-rm.sh \
	--after-remove scripts/package/post-rm.sh \
	--url https://kolide.io \
	--description "Ask your environment questions" \
	-m "kolide <engineering@kolide.co>" \
	--vendor "kolide" -a amd64 \
	--config-files etc/kolide/kolide.toml \
	--exclude */**.gitkeep \
	package/root/=/
Created package {:path=>"package/output/kolide-0.2.3+58.ebf59ed-1.x86_64.rpm"}
```

This PR will allow creating a package regardless of the existence of the kolide binary:
```shell
23:17:17 c1-linux (tl/fix-pacakge-creation) ~/Documents/Go/src/github.com/tonylambiris/kolide $ ls bin/kolide 
ls: cannot access 'bin/kolide': No such file or directory
23:17:40 c1-linux (tl/fix-pacakge-creation) ~/Documents/Go/src/github.com/tonylambiris/kolide $ make rpm64 
kolide
go version go1.7.3 linux/amd64
Go Path: /home/tlambiris/Documents/Go

Running go generate...
Building kolide...
strip bin/kolide
fpm -s dir -t rpm -n kolide -v 0.2.3+59.c4d17b0 -p package/output/ \
	--rpm-compression xz --rpm-os linux \
	--force \
	--before-install scripts/package/pre-inst.sh \
	--after-install scripts/package/post-inst.sh \
	--before-remove scripts/package/pre-rm.sh \
	--after-remove scripts/package/post-rm.sh \
	--url https://kolide.io \
	--description "Ask your environment questions" \
	-m "kolide <engineering@kolide.co>" \
	--vendor "kolide" -a amd64 \
	--config-files etc/kolide/kolide.toml \
	--exclude */**.gitkeep \
	package/root/=/
Created package {:path=>"package/output/kolide-0.2.3+59.c4d17b0-1.x86_64.rpm"}
```

Package creation for both deb and rpm still works:
```shell
23:17:56 c1-linux (tl/fix-pacakge-creation) ~/Documents/Go/src/github.com/tonylambiris/kolide $ make clean
# @go clean -r -i
23:18:24 c1-linux (tl/fix-pacakge-creation) ~/Documents/Go/src/github.com/tonylambiris/kolide $ make package 
kolide
go version go1.7.3 linux/amd64
Go Path: /home/tlambiris/Documents/Go

Running go generate...
Building kolide...
strip bin/kolide
fpm -s dir -t rpm -n kolide -v 0.2.3+59.c4d17b0 -p package/output/ \
	--rpm-compression xz --rpm-os linux \
	--force \
	--before-install scripts/package/pre-inst.sh \
	--after-install scripts/package/post-inst.sh \
	--before-remove scripts/package/pre-rm.sh \
	--after-remove scripts/package/post-rm.sh \
	--url https://kolide.io \
	--description "Ask your environment questions" \
	-m "kolide <engineering@kolide.co>" \
	--vendor "kolide" -a amd64 \
	--config-files etc/kolide/kolide.toml \
	--exclude */**.gitkeep \
	package/root/=/
Created package {:path=>"package/output/kolide-0.2.3+59.c4d17b0-1.x86_64.rpm"}
fpm -s dir -t deb -n kolide -v 0.2.3+59.c4d17b0 -p package/output/ \
	--force \
	--deb-compression xz \
	--before-install scripts/package/pre-inst.sh \
	--after-install scripts/package/post-inst.sh \
	--before-remove scripts/package/pre-rm.sh \
	--after-remove scripts/package/post-rm.sh \
	--url https://kolide.io \
	--description "Ask your environment questions" \
	-m "kolide <engineering@kolide.co>" \
	--vendor "kolide" -a amd64 \
	--config-files etc/kolide/kolide.toml \
	--exclude */**.gitkeep \
	package/root/=/
Debian packaging tools generally labels all files in /etc as config files, as mandated by policy, so fpm defaults to this behavior for deb packages. You can disable this default behavior with --deb-no-default-config-files flag {:level=>:warn}
Debian packaging tools generally labels all files in /etc as config files, as mandated by policy, so fpm defaults to this behavior for deb packages. You can disable this default behavior with --deb-no-default-config-files flag {:level=>:warn}
Created package {:path=>"package/output/kolide_0.2.3+59.c4d17b0_amd64.deb"}
```

In addition correct the variable referenced to `cn=` when creating certificates.